### PR TITLE
Replace function array dereferencing with PHP 5.x-friendly syntax.

### DIFF
--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -113,7 +113,8 @@ function get_blog_icon_value() {
         return $icon;
     }
     if ( \has_custom_logo() ) {
-        return \wp_get_attachment_image_src( \get_theme_mod( 'custom_logo' ) )[0];
+        $theme_mod = \wp_get_attachment_image_src( \get_theme_mod( 'custom_logo' ) );
+        return $theme_mod[0];
     }
     return null;
 }

--- a/includes/server/activities/delete.php
+++ b/includes/server/activities/delete.php
@@ -70,8 +70,10 @@ function delete_linked_comment( $object ) {
 
 function check_authorization( $activity ) {
     $object = $activity['object'];
-    $activity_origin = parse_url( $activity['id'] )['host'];
-    $object_origin = parse_url( $object['id'] )['host'];
+    $parsed_activity_id = parse_url( $activity['id'] );
+    $activity_origin = $parsed_activity_id['host'];
+    $parsed_object_id = parse_url( $object['id'] );
+    $object_origin = $parsed_object_id['host'];
     if ( ( !$activity_origin || !$object_origin ) || $activity_origin !== $object_origin ) {
         return new \WP_Error(
             'unauthorized',

--- a/includes/server/activities/update.php
+++ b/includes/server/activities/update.php
@@ -85,8 +85,10 @@ function handle_inbox( $actor_slug, $activity ) {
 
 function check_authorization( $activity ) {
     $object = $activity['object'];
-    $activity_origin = parse_url( $activity['id'] )['host'];
-    $object_origin = parse_url( $object['id'] )['host'];
+    $parsed_activity_id = parse_url( $activity['id'] );
+    $activity_origin = $parsed_activity_id['host'];
+    $parsed_object_id = parse_url( $object['id'] );
+    $object_origin = $parsed_object_id['host'];
     if ( ( !$activity_origin || !$object_origin ) || $activity_origin !== $object_origin ) {
         return new \WP_Error(
             'unauthorized',

--- a/includes/server/actors.php
+++ b/includes/server/actors.php
@@ -221,7 +221,8 @@ function get_user_actor( $user ) {
 }
 
 function make_icon_array( $icon_url ) {
-    $mime_type = wp_check_filetype( $icon_url )['type'];
+    $filetype = wp_check_filetype( $icon_url );
+    $mime_type = $filetype['type'];
     return array(
         'url' => $icon_url,
         'type' => 'Image',

--- a/includes/server/api.php
+++ b/includes/server/api.php
@@ -9,13 +9,18 @@ require_once plugin_dir_path( __FILE__ ) . 'following.php';
 require_once plugin_dir_path( __FILE__ ) . 'likes.php';
 require_once plugin_dir_path( __FILE__ ) . 'shares.php';
 
+function get_url_param( $request, $param ) {
+    $params = $request->get_url_params();
+    return $params[$param];
+}
+
 function get_actor( $request ) {
-    $actor = $request->get_url_params()['actor'];
+    $actor = get_url_param($request, 'actor');
     return \pterotype\actors\get_actor_by_slug( $actor );
 }
 
 function post_to_outbox( $request ) {
-    $actor_slug = $request->get_url_params()['actor'];
+    $actor_slug = get_url_param($request, 'actor');
     $body = $request->get_body();
     $activity = $body;
     if ( is_string( $body ) ) {
@@ -25,12 +30,12 @@ function post_to_outbox( $request ) {
 }
 
 function get_outbox( $request ) {
-    $actor_slug = $request->get_url_params()['actor'];
+    $actor_slug = get_url_param($request, 'actor');
     return \pterotype\outbox\get_outbox( $actor_slug );
 }
 
 function post_to_inbox( $request ) {
-    $actor_slug = $request->get_url_params()['actor'];
+    $actor_slug = get_url_param($request, 'actor');
     $body = $request->get_body();
     $activity = $body;
     if ( is_string( $body ) ) {
@@ -40,37 +45,37 @@ function post_to_inbox( $request ) {
 }
 
 function get_inbox( $request ) {
-    $actor_slug = $request->get_url_params()['actor'];
+    $actor_slug = get_url_param($request, 'actor');
     return \pterotype\inbox\get_inbox( $actor_slug );
 }
 
 function get_object( $request ) {
-    $id = $request->get_url_params()['id'];
+    $id = get_url_param($request, 'id');
     return \pterotype\objects\get_object( $id );
 }
 
 function get_following( $request ) {
-    $actor_slug = $request->get_url_params()['actor'];
+    $actor_slug = get_url_param($request, 'actor');
     return \pterotype\following\get_following_collection( $actor_slug );
 }
 
 function get_followers( $request ) {
-    $actor_slug = $request->get_url_params()['actor'];
+    $actor_slug = get_url_param($request, 'actor');
     return \pterotype\followers\get_followers_collection( $actor_slug );
 }
 
 function get_likes( $request ) {
-    $object_id = $request->get_url_params()['object'];
+    $object_id = get_url_param($request, 'object');
     return \pterotype\likes\get_likes_collection( $object_id );
 }
 
 function get_shares( $request ) {
-    $object_id = $request->get_url_params()['object'];
+    $object_id = get_url_param($request, 'object');
     return \pterotype\shares\get_shares_collection( $object_id );
 }
 
 function user_can_post_to_outbox( $request ) {
-    $actor_slug = $request->get_url_params()['actor'];
+    $actor_slug = get_url_param($request, 'actor');
     $actor_row = \pterotype\actors\get_actor_row_by_slug( $actor_slug );
     if ( ! $actor_row || is_wp_error( $actor_row ) ) {
         return false;

--- a/includes/util.php
+++ b/includes/util.php
@@ -82,7 +82,8 @@ function retrieve_local_object( $url ) {
 function is_local_url( $url ) {
     $parsed = parse_url( $url );
     if ( $parsed ) {
-        $site_host = parse_url( get_site_url() )['host'];
+        $parsed_site_url = parse_url( get_site_url() );
+        $site_host = $parsed_site_url['host'];
         return $parsed['host'] === $site_host;
     }
     return false;


### PR DESCRIPTION
WHAT
- Replace function array dereferencing in Pterotype with PHP 5.x-friendly syntax.

WHY
- The function array dereferencing syntax is not supported in PHP 5.x
- Although PHP 5.x is near EOL, it will be some time before all WP installs are migrated, especially in the case of shared hosting.
- see Issue: https://github.com/pterotype-project/pterotype/issues/16

HOW
- replace dereferencing with two-step dereferencing.

TESTING
- Manually tested the following endpoints with WP 4.9.8 and PHP 5.6
```
/wp-json/pterotype/v1/actor/-blog
/wp-json/pterotype/v1/actor/-blog/following
/wp-json/pterotype/v1/actor/-blog/followers
/wp-json/pterotype/v1/actor/-blog/liked
/wp-json/pterotype/v1/actor/-blog/inbox
/wp-json/pterotype/v1/actor/-blog/outbox
/wp-json/pterotype/v1/object/$N
/wp-json/pterotype/v1/object/$N/likes
/wp-json/pterotype/v1/object/$N/shares
```
